### PR TITLE
Ensure the RSS feed is linked in <head>

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,6 +5,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{{ .Site.Title }}</title>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
+        {{ with .OutputFormats.Get "rss" -}}
+            {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+        {{ end -}}
     </head>
     <body>
         <nav class="navbar is-dark" role="navigation" aria-label="main navigation">


### PR DESCRIPTION
The rss was being generated but wasn't discoverable by pointing my reader at the root domain.
Checked hugo docs (https://gohugo.io/templates/rss/) to confirm how to add RSS link.

Thanks for the great posts through the year.